### PR TITLE
Use temporary cache for Most pane.

### DIFF
--- a/ppdorg/sites/all/modules/custom/pp_frontpage/plugins/content_types/most.inc
+++ b/ppdorg/sites/all/modules/custom/pp_frontpage/plugins/content_types/most.inc
@@ -58,7 +58,7 @@ function pp_frontpage_most_content_type_render($subtype, $conf, $panel_args, $co
     $output .= theme('table', array('header' => $table_header, 'rows' => $table_data));
   }
 
-  cache_set(__FUNCTION__, $output);
+  cache_set(__FUNCTION__, $output, 'cache', CACHE_TEMPORARY);
 
   $block->content = $output;
   return $block;


### PR DESCRIPTION
Most frontpage pane cache settings are permanent. They should be temporary so they will get cleared time to time.
