### PR TITLE
Add per user clean up to clear stat form

### DIFF
--- a/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.pages.inc
+++ b/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.pages.inc
@@ -90,10 +90,23 @@ function ppgetstat_reset_form($form, $form_state) {
   $form['stats_period'] = array(
     '#type' => 'textfield',
     '#title' => t('Scanning period'),
-    '#required' => TRUE,
     '#element_validate' => array('element_validate_integer_positive'),
     '#default_value' => variable_get('ppgetstat_stats_period', 6 * 30 * 24 * 60 * 60),
     '#description' => t('For debugging purposes we can shorten period of grabbing stats. By default it is half a year 15552000, but we can set it to one month 2592000.')
+  );
+
+  $titles = array();
+  foreach (node_load_multiple(array(), array('type' => PPGETSTAT_USER_NODE_TYPE)) as $user_node) {
+    $titles[] = $user_node->title;
+  }
+
+  $form['users'] = array(
+    '#type' => 'select',
+    '#multiple' => TRUE,
+    '#title' => t('Clear stats by user'),
+    '#options' => $titles,
+    '#default_value' => '',
+    '#prefix' => t('or')
   );
 
   $form['submit'] = array(
@@ -108,23 +121,45 @@ function ppgetstat_reset_form($form, $form_state) {
  * Submit handler for reset form.
  */
 function ppgetstat_reset_form_submit($form, $form_state) {
-  variable_set('ppgetstat_stats_period', $form_state['values']['stats_period']);
+  if (!empty($form_state['values']['stats_period'])) {
+    variable_set('ppgetstat_stats_period', $form_state['values']['stats_period']);
 
-  variable_del('ppgetstat_last_statsjobs_timestamp');
-  db_query('TRUNCATE TABLE {ppgetstat}');
+    variable_del('ppgetstat_last_statsjobs_timestamp');
+    db_query('TRUNCATE TABLE {ppgetstat}');
+
+    drupal_set_message(t('Statistics resetted.'));
+  }
+  elseif (!empty($form_state['values']['users'])) {
+    $users = node_load_multiple($form_state['values']['users']);
+
+    $doids = array();
+    foreach ($users as $user) {
+      if (!empty($user->field_user_id[LANGUAGE_NONE][0]['value'])) {
+        $doids[] = $user->field_user_id[LANGUAGE_NONE][0]['value'];
+      }
+    }
+
+    db_delete('ppgetstat')
+      ->condition('doid', $doids, 'IN')
+      ->execute();
+
+    drupal_set_message(t('Statistics for given users was cleared.'));
+  }
 
   $defined_queues = array();
+
   if (function_exists('queue_ui_defined_queues')) {
     $defined_queues = queue_ui_defined_queues();
   }
+
   foreach (array('stats_jobs', 'dorg_scrapping') as $queue_name) {
     $queue = DrupalQueue::get($queue_name);
+
     if (isset($defined_queues[$queue_name]['delete'])) {
       $function = $defined_queues[$queue_name]['delete'];
       $function($queue);
     }
+
     $queue->deleteQueue();
   }
-
-  drupal_set_message(t('Statistics resetted.'));
 }


### PR DESCRIPTION
We have lots of broken data on production right now so it will allow us at least regenerate it for specific user.
