### PR TITLE
Use another last_checked timestamp for jobs

### DIFF
--- a/ppdorg/sites/all/modules/custom/pp_frontpage/plugins/content_types/most.inc
+++ b/ppdorg/sites/all/modules/custom/pp_frontpage/plugins/content_types/most.inc
@@ -35,7 +35,7 @@ function pp_frontpage_most_content_type_render($subtype, $conf, $panel_args, $co
     . 'WHERE type = :type AND timestamp > :timestamp '
     . 'GROUP BY doid ORDER BY counter DESC LIMIT 0,5';
 
-  $last_thee_months = REQUEST_TIME - 3 * 30 * 24 * 60 * 60;
+  $last_thee_months = REQUEST_TIME - PPGETSTAT_DEFAULT_TIME_PERIOD_FOR_SCANNING;
 
   $types = array(
     'Commits' => PPGETSTAT_TYPE_COMMITS,

--- a/ppdorg/sites/all/modules/custom/ppgetstat/ppcc/ppcc.module
+++ b/ppdorg/sites/all/modules/custom/ppgetstat/ppcc/ppcc.module
@@ -8,7 +8,7 @@
 // Commmits type of data.
 define('PPGETSTAT_TYPE_CORE_COMMITS', 2);
 // Core commit pages per day.
-define('PPGETSTAT_CORE_COMMITS_PAGES_PER_DAY', 6);
+define('PPGETSTAT_CORE_COMMITS_PAGES_PER_DAY', 10);
 
 /**
  * Implements hook_ppgetstat_stats_job().
@@ -16,16 +16,16 @@ define('PPGETSTAT_CORE_COMMITS_PAGES_PER_DAY', 6);
 function ppcc_ppgetstat_stats_job($user_node) {
   $doid = $user_node->field_user_id[LANGUAGE_NONE][0]['value'];
 
-  $last_scan = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
+  $last_scan_week = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
     array(':doid' => $doid, ':type' => PPGETSTAT_TYPE_CORE_COMMITS)
   )->fetchField();
 
-  $last_commit_timestamp = variable_get('ppgetstat_ppcc_last_commit_timestamp', array()) + array($doid => 0);
+  $last_commit_timestamp = variable_get('ppgetstat_ppcc_last_commit_timestamp', array($doid => array()));
+  $last_commit_timestamp[$doid] += array($last_scan_week => 0);
 
   $last_scan = max(array(
-    (int) $last_scan,
     REQUEST_TIME - PPGETSTAT_DEFAULT_TIME_PERIOD_FOR_SCANNING,
-    $last_commit_timestamp[$doid],
+    $last_commit_timestamp[$doid][$last_scan_week],
   ));
 
   if ($last_scan > REQUEST_TIME - 24 * 60 * 60) {
@@ -81,15 +81,6 @@ function _ppcc_parse_core_commits($page_content, $data) {
       throw new Exception(t('Cannot parse string %string to timestamp.', array('%string' => $date_string)));
     }
 
-    if ($first_commit_timestamp) {
-      $first_commit_timestamp = FALSE;
-      $last_commits = variable_get('ppgetstat_ppcc_last_commit_timestamp', array($data['doid'] => 0));
-      if (empty($last_commits[$data['doid']]) || $commit_timestamp > $last_commits[$data['doid']]) {
-        $last_commits[$data['doid']] = $commit_timestamp;
-        variable_set('ppgetstat_ppcc_last_commit_timestamp', $last_commits);
-      }
-    }
-
     // Stop scrapping any other pages as they are too old.
     if ($commit_timestamp <= $last_scan) {
       return FALSE;
@@ -102,6 +93,17 @@ function _ppcc_parse_core_commits($page_content, $data) {
     }
 
     $period_timestamp = $commit_timestamp - ($commit_timestamp % PPGETSTAT_TIME_PERIOD_GRANULARITY);
+    $last_commits = variable_get('ppgetstat_ppcc_last_commit_timestamp', array($data['doid'] => array($period_timestamp => 0)));
+
+    // Save latest commit's date per week into variable.
+    if ($first_commit_timestamp || empty($last_commits[$data['doid']][$period_timestamp])) {
+      $first_commit_timestamp = FALSE;
+      if (empty($last_commits[$data['doid']][$period_timestamp]) || $commit_timestamp > $last_commits[$data['doid']][$period_timestamp]) {
+        $last_commits[$data['doid']][$period_timestamp] = $commit_timestamp;
+        variable_set('ppgetstat_ppcc_last_commit_timestamp', $last_commits);
+      }
+    }
+
     if (!isset($commits_counter_array[$period_timestamp])) {
       $commits_counter_array[$period_timestamp] = 0;
     }

--- a/ppdorg/sites/all/modules/custom/ppgetstat/ppcmnt/ppcmnt.module
+++ b/ppdorg/sites/all/modules/custom/ppgetstat/ppcmnt/ppcmnt.module
@@ -14,16 +14,17 @@ define('PPGETSTAT_TYPE_COMMENTS', 3);
 function ppcmnt_ppgetstat_stats_job($user_node) {
   $doid = $user_node->field_user_id[LANGUAGE_NONE][0]['value'];
 
-  $last_scan = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
+  $last_scan_week = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
     array(':doid' => $doid, ':type' => PPGETSTAT_TYPE_COMMENTS)
   )->fetchField();
 
-  $last_comment_timestamp = variable_get('ppgetstat_ppcmnt_last_comment_timestamp', array()) + array($doid => 0);
+  $last_comment_timestamp = variable_get('ppgetstat_ppcmnt_last_comment_timestamp', array($doid => array()));
+
+  $last_comment_timestamp[$doid] += array($last_scan_week => 0);
 
   $last_scan = max(array(
-    (int) $last_scan,
     REQUEST_TIME - PPGETSTAT_DEFAULT_TIME_PERIOD_FOR_SCANNING,
-    $last_comment_timestamp[$doid],
+    $last_comment_timestamp[$doid][$last_scan_week],
   ));
 
   if ($last_scan > REQUEST_TIME - 24 * 60 * 60) {
@@ -149,17 +150,9 @@ function _ppcmnt_parse_post_page($page_content, $data) {
     $comment_element_date = clone $comment_element;
     $comment_date_string = $comment_element_date->find('time')->attr('datetime');
     $comment_timestamp = strtotime($comment_date_string);
+
     if (empty($comment_timestamp)) {
       throw new Exception(t('Cannot parse string %string to timestamp.', array('%string' => $comment_date_string)));
-    }
-
-    if ($first_commit_timestamp) {
-      $first_commit_timestamp = FALSE;
-      $last_comment = variable_get('ppgetstat_ppcmnt_last_comment_timestamp', array($data['doid'] => 0));
-      if (empty($last_comment[$data['doid']]) || ($comment_timestamp > $last_comment[$data['doid']])) {
-        $last_comment[$data['doid']] = $comment_timestamp;
-        variable_set('ppgetstat_ppcmnt_last_comment_timestamp', $last_comment);
-      }
     }
 
     if ($comment_timestamp <= $last_scan) {
@@ -169,11 +162,24 @@ function _ppcmnt_parse_post_page($page_content, $data) {
     // Extract comment's author nickname.
     $comment_element_nickname = clone $comment_element;
     $comment_nickname = $comment_element_nickname->find('a.username')->innerHTML();
+
     if ($comment_nickname != $nickname) {
       continue;
     }
 
     $period_timestamp = $comment_timestamp - ($comment_timestamp % PPGETSTAT_TIME_PERIOD_GRANULARITY);
+    $last_comment = variable_get('ppgetstat_ppcmnt_last_comment_timestamp', array($data['doid'] => array($period_timestamp => 0)));
+
+    // Save latest commit's date per week into variable.
+    if ($first_commit_timestamp || empty($last_comment[$data['doid']][$period_timestamp])) {
+      $first_commit_timestamp = FALSE;
+
+      if (empty($last_comment[$data['doid']][$period_timestamp]) || ($comment_timestamp > $last_comment[$data['doid']][$period_timestamp])) {
+        $last_comment[$data['doid']][$period_timestamp] = $comment_timestamp;
+        variable_set('ppgetstat_ppcmnt_last_comment_timestamp', $last_comment);
+      }
+    }
+
     if (!isset($comments_counter_array[$period_timestamp])) {
       $comments_counter_array[$period_timestamp] = 0;
     }

--- a/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.module
+++ b/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.module
@@ -156,15 +156,17 @@ function _ppgetstat_cron_createItem_stats_jobs() {
  */
 function ppgetstat_ppgetstat_stats_job($user_node) {
   $doid = $user_node->field_user_id[LANGUAGE_NONE][0]['value'];
-  $last_scan = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
+  $last_scan_week = db_query('SELECT timestamp FROM {ppgetstat} WHERE doid = :doid AND type = :type ORDER BY timestamp DESC LIMIT 1',
     array(':doid' => $doid, ':type' => PPGETSTAT_TYPE_COMMITS)
   )->fetchField();
 
-  $last_commit_timestamp = variable_get('ppgetstat_ppgetstat_last_commit_timestamp', array()) + array($doid => 0);
+  $last_commit_timestamp = variable_get('ppgetstat_ppgetstat_last_commit_timestamp', array($doid => array()));
+
+  $last_commit_timestamp[$doid] += array($last_scan_week => 0);
+
   $last_scan = max(array(
-    (int) $last_scan,
     REQUEST_TIME - PPGETSTAT_DEFAULT_TIME_PERIOD_FOR_SCANNING,
-    $last_commit_timestamp[$doid],
+    $last_commit_timestamp[$doid][$last_scan_week],
   ));
 
   if ($last_scan > REQUEST_TIME - 24 * 60 * 60) {
@@ -398,20 +400,23 @@ function _ppgetstat_parse_commits($page_content, $data) {
   foreach ($strings as $string) {
     $commit_timestamp = _ppgetstat_parse_commits_page_date($string->html());
 
-    if ($first_commit_timestamp) {
-      $first_commit_timestamp = FALSE;
-      $last_commits = variable_get('ppgetstat_ppgetstat_last_commit_timestamp', array($data['doid'] => 0));
-      if (empty($last_commits[$data['doid']]) || $commit_timestamp > $last_commits[$data['doid']]) {
-        $last_commits[$data['doid']] = $commit_timestamp;
-        variable_set('ppgetstat_ppgetstat_last_commit_timestamp', $last_commits);
-      }
-    }
-
     if ($commit_timestamp <= $last_scan) {
       break;
     }
 
     $period_timestamp = $commit_timestamp - ($commit_timestamp % PPGETSTAT_TIME_PERIOD_GRANULARITY);
+    $last_commits = variable_get('ppgetstat_ppgetstat_last_commit_timestamp', array($data['doid'] => array($period_timestamp => 0)));
+
+    // Save latest commit's date per week into variable.
+    if ($first_commit_timestamp || empty($last_commits[$data['doid']][$period_timestamp])) {
+      $first_commit_timestamp = FALSE;
+
+      if (empty($last_commits[$data['doid']][$period_timestamp]) || $commit_timestamp > $last_commits[$data['doid']][$period_timestamp]) {
+        $last_commits[$data['doid']][$period_timestamp] = $commit_timestamp;
+        variable_set('ppgetstat_ppgetstat_last_commit_timestamp', $last_commits);
+      }
+    }
+
     if (!isset($commits_counter_array[$period_timestamp])) {
       $commits_counter_array[$period_timestamp] = 0;
     }

--- a/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.pages.inc
+++ b/ppdorg/sites/all/modules/custom/ppgetstat/ppgetstat.pages.inc
@@ -134,6 +134,11 @@ function ppgetstat_reset_form_submit($form, $form_state) {
     variable_del('ppgetstat_last_statsjobs_timestamp');
     db_query('TRUNCATE TABLE {ppgetstat}');
 
+    variable_del('ppgetstat_ppcc_last_commit_timestamp');
+    variable_del('ppgetstat_ppcmnt_last_comment_timestamp');
+    variable_del('ppgetstat_ppgetstat_last_commit_timestamp');
+    variable_del('ppgetstat_last_statsjobs_timestamp');
+
     drupal_set_message(t('Statistics resetted.'));
   }
   elseif (!empty($form_state['values']['users'])) {


### PR DESCRIPTION
1) Add multiplier for core commits module to increase pages amount per day
2) Use last parsed commit/comment timestamp instead of week beginning timestamp for condition.
